### PR TITLE
Scoring updated, eliminations no longer cause loss of points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ venv/
 # nginx basic auth password file
 nginx/.htpasswd
 
+# data files
+data/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,10 @@ PostgreSQL → shiny/app.R (at render time) → cumulative line graph
 - Two Shiny containers, same image, differ only by `POOL_ID` env var (1 or 2) → ports 3838 / 3839
 - Scoring lives in `shiny/scoring.R` (`compute_scores()`), applied at render time, never stored
 - Scoring: skaters = `goals + assists`; goalies = `goals + assists + wins×2 + shutouts×3`
-- Players on eliminated teams score 0 from `eliminated_date` onward; prior points are kept
+- Eliminated players' stats freeze on hockey-reference at their final total — scoring ignores the eliminations table entirely and scores from cumulative stats only (scores never drop, they plateau)
 - `db/hockey_player_key.csv` is the name-mapping seed file (form names ↔ hockey-reference names)
 
-Scraper quirks (duplicate columns, sub-headers, elimination logic): `docs/scraper.md`
+Scraper quirks (duplicate columns, sub-headers, encoding): `docs/scraper.md`
 
 ## Legacy Code
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ An **R Shiny** application reads from the local PostgreSQL instance and renders 
 
 ### Elimination Rule
 
-- Points are **cumulative and never deducted** — a player's historical points are always retained.
-- Once a player's NHL team is **eliminated from the playoffs**, that player stops producing points on the next nightly update.
-- Players on active teams continue to accumulate until their team is eliminated or the playoffs end.
+- Points are **cumulative and never deducted** — a player's score never drops.
+- Once a player's team is eliminated, their stats on hockey-reference freeze at their final total. Subsequent scrapes continue to show that frozen total, so their contribution to the pool also stays frozen — it just stops growing.
+- No special elimination logic is needed in scoring: the scraper still records eliminations, but the Shiny app ignores them entirely and scores directly from the cumulative stats snapshot.
 
-> **Example:** If a participant picks a player whose team exits in Round 1, those Round 1 points are kept — but no further points are added from Round 2 onward.
+> **Example:** If a participant picks a player whose team exits in Round 1 with 8 points, those 8 points are kept permanently — the line on the graph simply goes flat from that date onward.
 
 ---
 
@@ -84,12 +84,12 @@ Google Form (picks)
                                                         │
   NHL Site / API  ──►  nightly scraper (21:00 EST)  ──►  stats table (dated snapshots)
                                                         │
-                                                   eliminations table
-                                                   (team → round_eliminated)
+                                                   eliminations table        (recorded for reference;
+                                                   (team → round_eliminated)  not used in scoring)
                                                         │
                                                         ▼
                                                R Shiny Dashboard
-                                               (score calc at query time)
+                                               (score calc at query time — cumulative stats only)
                                                         │
                                                         ▼
                                             DuckDNS endpoint (home server)
@@ -160,11 +160,9 @@ Export each pool's Google Form responses as CSV. Before running the ingest, make
 Everything else can be left as-is. The script only reads:
 - `name` — participant display name
 - `pool_id` — pool identifier
-- Columns matching `"Pick a center/winger/defenseman/goalie (group N)..."` — exactly 27 expected (8 centers, 10 wingers, 6 defensemen, 3 goalies)
+- Columns matching `"Pick a forward/defenseman/goalie (group N)..."` — exactly 24 expected (12 forwards, 8 defensemen, 4 goalies)
 
 All other columns (`Timestamp`, `Email Address`, etc.) are ignored.
-
-See `legacy/data/fake_picks.csv` as a format reference.
 
 #### Step 2 — Apply schema to the production database
 

--- a/db/hockey_player_key.csv
+++ b/db/hockey_player_key.csv
@@ -1,164 +1,113 @@
-﻿Form in Google Forms,Form in hockey reference,HTML
-ANDERSEN CAR,Frederik Andersen,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-BINNINGTON STL,Jordan Binnington,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-BLACKWOOD COL,Mackenzie Blackwood,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-BOBROVSKY FLA,Sergei Bobrovsky,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-DAWS NJD,Daws,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-FLEURY MIN,Fleury,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-GUSTAFSSON MIN,Filip Gustavsson,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-HELLEBUYCK WPG,Connor Hellebuyck,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-HILL VGK,Adin Hill,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-KOTCHETKOV CAR,Kotchetkov,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-KUEMPER LAK,Darcy Kuemper,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-LINDGREN WSH,Lindgren,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-MARKSTROM NJD,Jacob MarkstrÃ¶m,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-MONTEMBEAULT MTL,Sam Montembeault,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-OETTINGER DAL,Jake Oettinger,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-PICKARD EDM,Calvin Pickard,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-RITTICH LAK,Rittich,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-SAMSONOV VGK,Samsonov,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-SKINNER EDM,Stuart Skinner,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-STOLARZ TOR,Anthony Stolarz,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-THOMPSON WSH,Logan Thompson,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-ULLMARK OTT,Linus Ullmark,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-VASILEVSKIY TBL,Andrei Vasilevskiy,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-WOLL TOR,Woll,https://www.hockey-reference.com/playoffs/NHL_2025_goalies.html
-AARON EKBLAD FLA,Aaron Ekblad,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ADAM HENRIQUE EDM,Adam Henrique,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ADAM LOWRY WPG,Adam Lowry,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ADRIAN KEMPE LAK,Adrian Kempe,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ALEKSANDER BARKOV FLA,Aleksander Barkov,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ALEX OVECHKIN WSH,Alex Ovechkin,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ALEX PIETRANGELO VGK,Alex Pietrangelo,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ALIAKSEI PROTAS WSH,Aliaksei Protas,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ANDREI KUZMENKO LAK,Andrei Kuzmenko,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ANDREI SVECHNIKOV CAR,Andrei Svechnikov,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ANTHONY CIRELLI TBL,Anthony Cirelli,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ANTON LUNDELL FLA,Anton Lundell,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ANZE KOPITAR LAK,Anže Kopitar,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ARTTURI LEHKONEN COL,Artturi Lehkonen,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-AUSTON MATTHEWS TOR,Auston Matthews,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BOBBY MCMANN TOR,Bobby McMann,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BRAD MARCHAND FLA,Brad Marchand,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BRADY TKACHUK OTT,Brady Tkachuk,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BRANDON HAGEL TBL,Brandon Hagel,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BRANDT CLARKE LAK,Brandt Clarke,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BRAYDEN POINT TBL,Brayden Point,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BRAYDEN SCHENN STL,Brayden Schenn,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BRETT HOWDEN VGK,Brett Howden,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BROCK FABER MIN,Brock Faber,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-BROCK NELSON COL,Brock Nelson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-CALE MAKAR COL,Cale Makar,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-CAM FOWLER STL,Cam Fowler,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-CARTER VERHAEGHE FLA,Carter Verhaeghe,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-CHARLIE COYLE COL,Charlie Coyle,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-CLAUDE GIROUX OTT,Claude Giroux,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-COLE CAUFIELD MTL,Cole Caufield,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-COLE PERFETTI WPG,Cole Perfetti,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-COLTON PARAYKO STL,Colton Parayko,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-CONNOR MCDAVID EDM,Connor McDavid,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-CONNOR MCMICHAEL WSH,Connor McMichael,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-COREY PERRY EDM,Corey Perry,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DARNELL NURSE EDM,Darnell Nurse,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DAWSON MERCER NJD,Dawson Mercer,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DEVON TOEWS COL,Devon Toews,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DMITRY ORLOV CAR,Dmitry Orlov,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DOUGIE HAMILTON NJD,Dougie Hamilton,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DRAKE BATHERSON OTT,Drake Batherson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DREW DOUGHTY LAK,Drew Doughty,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DYLAN COZENS OTT,Dylan Cozens,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DYLAN HOLLOWAY STL,Dylan Holloway,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-DYLAN STROME WSH,Dylan Strome,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ESA LINDELL DAL,Esa Lindell,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-EVAN BOUCHARD EDM,Evan Bouchard,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-GABRIEL VILARDI WPG,Gabriel Vilardi,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-GUSTAV FORSLING FLA,Gustav Forsling,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-IVAN BARBASHEV VGK,Ivan Barbashev,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-IVAN DEMIDOV MTL,Ivan Demidov,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JACK EICHEL VGK,Jack Eichel,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JACK HUGHES NJD,Jack Hughes,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JACK ROSLOVIC CAR,Jack Roslovic,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JAKE EVANS MTL,Jake Evans,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JAKE GUENTZEL TBL,Jake Guentzel,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JAKE NEIGHBOURS STL,Jake Neighbours,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JAKE SANDERSON OTT,Jake Sanderson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JAKE WALMAN EDM,Jake Walman,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JAKOB CHYCHRUN WSH,Jakob Chychrun,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JAMIE BENN DAL,Jamie Benn,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JARED SPURGEON MIN,Jared Spurgeon,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JASON ROBERTSON DAL,Jason Robertson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JESPER BRATT NJD,Jesper Bratt,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JOEL ERIKSSON EK MIN,Joel Eriksson Ek,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JOHN CARLSON WSH,John Carlson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JOHN TAVARES TOR,John Tavares,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JONATHAN DROUIN COL,Jonathan Drouin,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JORDAN KYROU STL,Jordan Kyrou,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JOSH MORRISSEY WPG,Josh Morrissey,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JURAJ SLAFKOVSKY MTL,Juraj Slafkovsky,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-JUSTIN FAULK STL,Justin Faulk,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-KEVIN FIALA LAK,Kevin Fiala,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-KIRILL KAPRIZOV MIN,Kirill Kaprizov,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-KYLE CONNOR WPG,Kyle Connor,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-LANE HUTSON MTL,Lane Hutson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-LEON DRAISAITL EDM,Leon Draisaitl,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-LOGAN STANKOVEN CAR,Logan Stankoven,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-LUKE HUGHES NJD,Luke Hughes,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MARCO ROSSI MIN,Marco Rossi,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MARK SCHEIFELE WPG,Mark Scheifele,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MARK STONE VGK,Mark Stone,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MARTIN NECAS COL,Martin Necas,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MASON MARCHMENT DAL,Mason Marchment,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MATS ZUCCARELLO MIN,Mats Zuccarello,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MATT BOLDY MIN,Matt Boldy,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MATT DUCHENE DAL,Matt Duchene,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MATTHEW KNIES TOR,Matthew Knies,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MATTHEW TKACHUK FLA,Matthew Tkachuk,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MATTIAS EKHOLM EDM,Mattias Ekholm,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MAX DOMI TOR,Max Domi,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MIKAEL GRANLUND DAL,Mikael Granlund,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MIKE MATHESON MTL,Mike Matheson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MIKKO RANTANEN DAL,Mikko Rantanen,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MITCH MARNER TOR,Mitch Marner,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-MORGAN RIELLY TOR,Morgan Rielly,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NATHAN MACKINNON COL,Nathan MacKinnon,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NEAL PIONK WPG,Neal Pionk,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NICK PAUL TBL,Nick Paul,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NICK SUZUKI MTL,Nick Suzuki,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NICO HISCHIER NJD,Nico Hischier,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NICOLAS ROY VGK,Nicolas Roy,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NIKITA KUCHEROV TBL,Nikita Kucherov,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NIKOLAJ EHLERS WPG,Nikolaj Ehlers,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-NOAH HANIFIN VGK,Noah Hanifin,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-OLIVER BJORKSTRAND TBL,Oliver Bjorkstrand,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-PATRIK LAINE MTL,Patrik Laine,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-PAVEL BUCHNEVICH STL,Pavel Buchnevich,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-PAVEL DOROFEYEV VGK,Pavel Dorofeyev,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-PHILLIP DANAULT LAK,Phillip Danault,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-PIERRE-LUC DUBOIS WSH,Pierre-Luc Dubois,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-QUINTON BYFIELD LAK,Quinton Byfield,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-RYAN NUGENT-HOPKINS EDM,Ryan Nugent-Hopkins,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SAM BENNETT FLA,Sam Bennett,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SAM REINHART FLA,Sam Reinhart,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SCOTT MORROW CAR,Scott Morrow,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SEBASTIAN AHO CAR,Sebastian Aho,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SETH JARVIS CAR,Seth Jarvis,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SETH JONES FLA,Seth Jones,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SHANE PINTO OTT,Shane Pinto,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SHAYNE GOSTISBEHERE CAR,Shayne Gostisbehere,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-SHEA THEODORE VGK,Shea Theodore,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-TAYLOR HALL CAR,Taylor Hall,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-THOMAS CHABOT OTT,Thomas Chabot,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-THOMAS HARLEY DAL,Thomas Harley,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-TIM STUTZLE OTT,Tim Stützle,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-TIMO MEIER NJD,Timo Meier,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-TOM WILSON WSH,Tom Wilson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-TOMAS HERTL VGK,Tomáš Hertl,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-TREVOR MOORE LAK,Trevor Moore,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-TYLER SEGUIN DAL,Tyler Seguin,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-VALERI NICHUSHKIN COL,Valeri Nichushkin,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-VICTOR HEDMAN TBL,Victor Hedman,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-WILLIAM KARLSSON VGK,William Karlsson,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-WILLIAM NYLANDER TOR,William Nylander,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-WYATT JOHNSTON DAL,Wyatt Johnston,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ZACH HYMAN EDM,Zach Hyman,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
-ZACK BOLDUC STL,Zachary Bolduc,https://www.hockey-reference.com/playoffs/NHL_2025_skaters.html
+Form in Google Forms,Form in hockey reference,HTML
+Adin Hill (VGK),Adin Hill,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Adrian Kempe (LAK),Adrian Kempe,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Alex Pietrangelo (VGK),Alex Pietrangelo,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Alex Tuch (BUF),Alex Tuch,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Andre Svechnikov (CAR),Andrei Svechnikov,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Andrei Svechnikov (CAR),Andrei Svechnikov,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Andrei Vasilevskiy (TBL),Andrei Vasilevskiy,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Artemi Panarin (LAK),Artemi Panarin,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Artturi Lehkonen (COL),Artturi Lehkonen,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Brady Tkachuk (OTT),Brady Tkachuk,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Brandon Hagel (TBL),Brandon Hagel,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Brandt Clarke (LAK),Brandt Clarke,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Brayden Point (TBL),Brayden Point,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Brent Burns (COL),Brent Burns,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Brock Faber (MIN),Brock Faber,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Bryan Rust (PIT),Bryan Rust,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Cale Makar (COL),Cale Makar,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Cam York (PHI),Cameron York,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Charlie McAvoy (BOS),Charlie McAvoy,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Claude Giroux (OTT),Claude Giroux,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Clayton Keller (UTA),Clayton Keller,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Cole Caufield (MTL),Cole Caufield,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Connor McDavid (EDM),Connor McDavid,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Darcy Kuemper (LAK),Darcy Kuemper,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Darnell Nurse (EDM),Darnell Nurse,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+David Pastrnak (BOS),David Pastrňák,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Devon Toews (COL),Devon Toews,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Drake Batherson (OTT),Drake Batherson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Dylan Guenther (UTA),Dylan Guenther,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Erik Karlsson (PIT),Erik Karlsson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Esa Lindell (DAL),Esa Lindell,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Evan Bouchard (EDM),Evan Bouchard,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Evgeni Malkin (PIT),Evgeni Malkin,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Filip Gustavsson (MIN),Filip Gustavsson,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Frank Vatrano (ANA),Frank Vatrano,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Hampus Lindholm (BOS),Hampus Lindholm,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+J.J. Peterka (BUF),JJ Peterka,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jaccob Slavin (CAR),Jaccob Slavin,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jack Eichel (VGK),Jack Eichel,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jack Roslovic (EDM),Jack Roslovic,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jake Guentzel (TBL),Jake Guentzel,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jake Oettinger (DAL),Jake Oettinger,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Jake Sanderson (OTT),Jake Sanderson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jamie Drysdale (PHI),Jamie Drysdale,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jason Robertson (DAL),Jason Robertson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jeremy Swayman (BOS),Jeremy Swayman,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Joel Edmundson (LAK),Joel Edmundson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Joel Eriksson Ek (MIN),Joel Eriksson Ek,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Jordan Spence (OTT),Jordan Spence,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Josh Doan (BUF),Josh Doan,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Juraj Slafkovsky (MTL),Juraj Slafkovsky,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Kaiden Guhle (MTL),Kaiden Guhle,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Karel Vejmelka (UTA),Karel Vejmelka,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Kirby Dach (MTL),Kirby Dach,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Kirill Kaprizov (MIN),Kirill Kaprizov,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Lane Hutson (MTL),Lane Hutson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Leo Carlsson (ANA),Leo Carlsson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Linus Ullmark (OTT),Linus Ullmark,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Logan Cooley (UTA),Logan Cooley,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Lukas Dostal (ANA),Lukáš Dostál,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Mark Stone (VGK),Mark Stone,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Martin Necas (COL),Martin Nečas,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Mason McTavish (ANA),Mason McTavish,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Matt Boldy (MIN),Matt Boldy,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Mattias Ekholm (EDM),Mattias Ekholm,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Mattias Samuelsson (BUF),Mattias Samuelsson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Matvei Michkov (PHI),Matvei Michkov,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Michael Bunting (DAL),Michael Bunting,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Mike Matheson (MTL),Mike Matheson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Mikhail Sergachev (UTA),Mikhail Sergachev,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Mikko Rantanen (DAL),Mikko Rantanen,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Miro Heiskanen (DAL),Miro Heiskanen,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Mitchell Marner (VGK),Mitch Marner,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Morgan Geekie (BOS),Morgan Geekie,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Nathan MacKinnon (COL),Nathan MacKinnon,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Nick Schmaltz (UTA),Nick Schmaltz,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Nick Suzuki (MTL),Nick Suzuki,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Nikita Kucherov (TBL),Nikita Kucherov,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Noah Hanifin (VGK),Noah Hanifin,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Olen Zellweger (ANA),Olen Zellweger,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Owen Power (BUF),Owen Power,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Owen Tippett (PHI),Owen Tippett,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Pavel Mintyukov (ANA),Pavel Mintyukov,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Pavel Zacha (BOS),Pavel Zacha,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Pyotr Kochetkov (CAR),Pyotr Kochetkov,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Quinn Hughes (MIN),Quinn Hughes,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Quinton Byfield (LAK),Quinton Byfield,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Radko Gudas (ANA),Radko Gudas,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Rickard Rakell (PIT),Rickard Rakell,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Ryan McDonagh (TBL),Ryan McDonagh,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Ryan Shea (PIT),Ryan Shea,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Sam Montembeault (MTL),Samuel Montembeault,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Samuel Ersson (PHI),Samuel Ersson,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Scott Wedgewood (COL),Scott Wedgewood,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Sean Walker (CAR),Sean Walker,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Sebastian Aho (CAR),Sebastian Aho,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Seth Jarvis (CAR),Seth Jarvis,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Shea Theodore (VGK),Shea Theodore,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Sidney Crosby (PIT),Sidney Crosby,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Stuart Skinner (PIT),Stuart Skinner,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Tage Thompson (BUF),Tage Thompson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Thomas Chabot (OTT),Thomas Chabot,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Thomas Harley (DAL),Thomas Harley,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Tim Stützle (OTT),Tim Stützle,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Travis Konecny (PHI),Travis Konecny,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Trevor Moore (LAK),Trevor Moore,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Trevor Zegras (PHI),Trevor Zegras,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Tristan Jarry (EDM),Tristan Jarry,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Ukko-Pekka Luukkonen (BUF),Ukko-Pekka Luukkonen,https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html
+Victor Hedman (TBL),Victor Hedman,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Viktor Arvidsson (BOS),Viktor Arvidsson,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html
+Wyatt Johnston (DAL),Wyatt Johnston,https://www.hockey-reference.com/playoffs/NHL_2026_skaters.html

--- a/db/ingest_picks.py
+++ b/db/ingest_picks.py
@@ -5,12 +5,12 @@ Standalone utility: ingest a prepared picks CSV into PostgreSQL players + picks 
 Expected CSV columns:
   - name      participant display name
   - pool_id   integer pool identifier (1 or 2)
-  - pick columns matching "Pick a (center|winger|defenseman|goalie)..." in order:
-      8 centers, 10 wingers, 6 defensemen, 3 goalies
+  - pick columns matching "Pick a (forward|defenseman|goalie)..." in order:
+      12 forwards, 8 defensemen, 4 goalies
 
 Usage:
-    DB_NAME=nhl_dev python db/ingest_picks.py legacy/data/pool1_picks.csv
-    DB_NAME=nhl_dev python db/ingest_picks.py legacy/data/pool2_picks.csv
+    DB_NAME=nhl python db/ingest_picks.py data/2026_nhl_pool1.csv
+    DB_NAME=nhl python db/ingest_picks.py data/2026_nhl_pool2.csv
 """
 
 import csv
@@ -28,10 +28,9 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 PLAYER_KEY_CSV = Path(__file__).parent / "hockey_player_key.csv"
 
 SLOTS = (
-    [f"center_{i}"     for i in range(1, 9)]   +  # 8 centers
-    [f"winger_{i}"     for i in range(1, 11)]  +  # 10 wingers
-    [f"defenseman_{i}" for i in range(1, 7)]   +  # 6 defensemen
-    [f"goalie_{i}"     for i in range(1, 4)]      # 3 goalies
+    [f"forward_{i}"    for i in range(1, 13)]  +  # 12 forwards
+    [f"defenseman_{i}" for i in range(1, 9)]   +  # 8 defensemen
+    [f"goalie_{i}"     for i in range(1, 5)]      # 4 goalies
 )
 
 
@@ -73,7 +72,7 @@ def ingest_picks(conn, picks_csv: Path, player_lookup: dict) -> tuple[int, int]:
 
         pick_cols = [
             c for c in reader.fieldnames
-            if re.search(r"Pick a (center|winger|defenseman|goalie)", c, re.IGNORECASE)
+            if re.search(r"Pick a (forward|defenseman|goalie)", c, re.IGNORECASE)
         ]
         if len(pick_cols) != len(SLOTS):
             raise ValueError(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,8 +60,8 @@ Hockey-reference uses full proper names (e.g. `Aaron Ekblad`). The Google Form u
 1. Browser hits `localhost:3838`
 2. Shiny server starts `app.R` for `POOL_ID=1`
 3. App connects to PostgreSQL via `host.docker.internal:5432`
-4. Four queries: `picks` (filtered to pool 1), `skaters`, `goalies`, `eliminations`
-5. `compute_scores()` in `scoring.R` joins and scores across all dates
+4. Three queries: `picks` (filtered to pool 1), `skaters`, `goalies`
+5. `compute_scores()` in `scoring.R` joins picks against cumulative stats across all dates
 6. `ggplot2` renders the cumulative line graph
 7. Graph is returned to the browser as a PNG
 

--- a/docs/network-setup.md
+++ b/docs/network-setup.md
@@ -187,12 +187,25 @@ The containers communicate over Docker's internal network using service names (`
 
 The pool pages are password-protected. The credentials file is at `nginx/.htpasswd` (gitignored).
 
-To create or add a user:
-
 ```bash
 sudo apt install apache2-utils   # one-time
-htpasswd -c nginx/.htpasswd USERNAME   # -c creates new file (use once)
-htpasswd nginx/.htpasswd USERNAME      # add additional users (no -c)
+
+# Create the file with a first user (-c overwrites if file exists)
+htpasswd -c nginx/.htpasswd USERNAME
+
+# Add another user (omit -c to append)
+htpasswd nginx/.htpasswd USERNAME
+
+# List existing usernames
+cut -d: -f1 nginx/.htpasswd
+
+# Remove a user
+htpasswd -D nginx/.htpasswd USERNAME
+```
+
+After any change, reload nginx to pick it up:
+```bash
+docker compose restart nginx
 ```
 
 Users enter these credentials when first visiting the site. The browser caches them for the session.
@@ -206,7 +219,7 @@ Users enter these credentials when first visiting the site. The browser caches t
 | Check cert expiry | `sudo certbot certificates` |
 | Force renew early | `sudo certbot renew --force-renewal` |
 | Test renewal automation | `sudo certbot renew --dry-run` |
-| Restart all services | `cd ~/projects/NHLPlayoffPool_dev && docker compose restart` |
+| Restart all services | `cd ~/projects/NHLPlayoffPool && docker compose restart` |
 | View nginx logs | `docker compose logs -f nginx` |
 | Add/change pool password | `htpasswd nginx/.htpasswd USERNAME` then `docker compose restart nginx` |
 | DuckDNS IP update fails | Check `cat /tmp/duckdns.log`; verify token in crontab |

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -10,9 +10,11 @@
 
 | URL | Data extracted |
 |-----|----------------|
-| `hockey-reference.com/playoffs/NHL_2025_skaters.html` | Goals, assists per skater |
-| `hockey-reference.com/playoffs/NHL_2025_goalies.html` | Wins, shutouts, goals, assists per goalie |
-| `hockey-reference.com/playoffs/NHL_2025.html` | Playoff bracket — used to derive eliminations |
+| `hockey-reference.com/playoffs/NHL_{SCRAPE_YEAR}_skaters.html` | Goals, assists per skater |
+| `hockey-reference.com/playoffs/NHL_{SCRAPE_YEAR}_goalies.html` | Wins, shutouts, goals, assists per goalie |
+| `hockey-reference.com/playoffs/NHL_{SCRAPE_YEAR}.html` | Playoff bracket — used to derive eliminations |
+
+`SCRAPE_YEAR` is set via the `.env` file and passed into the container as an environment variable.
 
 All stats on hockey-reference are **cumulative season totals**, not per-game. Each nightly scrape captures a full snapshot of where every player stands to date.
 
@@ -34,9 +36,13 @@ This is necessary because cron does not inherit the container's environment vari
 
 Hockey-reference stats pages use an HTML `<table id="stats">` structure with a few quirks:
 
-**Sub-header rows:** The `<tbody>` contains repeated header rows (with CSS class `thead`) interspersed throughout the data. These are skipped by checking `tr.get("class", [])`.
+**Column header location:** The outer `<thead>` only contains group-level headers (`Scoring`, `Goals`, etc.). The actual column names (`Player`, `Tm`, `G`, `A`, …) live in the first `<tr class="thead">` row inside `<tbody>` for the skaters page, or in the last `<tr>` of the outer `<thead>` for the goalies page. `parse_stats_table()` checks both locations and uses whichever is present.
+
+**Sub-header rows:** The `<tbody>` may contain repeated header rows (CSS class `thead`) interspersed throughout the data. These are skipped when iterating data rows.
 
 **Duplicate column names:** The skaters table has two sets of columns named `EV`, `PP`, and `SH` (even-strength and power-play splits). `parse_stats_table()` deduplicates these by appending `_1` to the second occurrence (e.g. `EV` and `EV_1`). Only `G` (goals) and `A` (assists) are used, so this doesn't affect the data written to the DB — but it prevents dict key collisions during parsing.
+
+**Unicode player names:** `fetch_soup()` passes `resp.content` (raw bytes) to BeautifulSoup rather than `resp.text`. This lets lxml detect the page encoding from the HTML meta tag, preventing mojibake for players with diacritics in their names (e.g. `Tim Stützle`, `Martin Nečas`).
 
 **Empty-name rows:** Some rows have a blank `Player` cell (separator rows). `parse_stats_table()` returns these as-is; `scrape_skaters()` and `scrape_goalies()` filter them out with `if not name or not team: continue`.
 
@@ -44,7 +50,9 @@ Hockey-reference stats pages use an HTML `<table id="stats">` structure with a f
 
 ## Deriving eliminations
 
-The playoff bracket page (`NHL_2025.html`) has a summary table where each row looks like:
+> **Note:** The eliminations table is still populated by the scraper for reference, but the Shiny scoring logic no longer uses it. Eliminated players' stats naturally freeze on hockey-reference at their final cumulative total — the scoring app reads those frozen totals directly, so scores plateau rather than drop.
+
+The playoff bracket page (`NHL_{SCRAPE_YEAR}.html`) has a summary table where each row looks like:
 
 ```
 Round name  |  Score  |  Series description
@@ -98,4 +106,4 @@ GOALIES_URL  = "https://www.hockey-reference.com/playoffs/NHL_2026_goalies.html"
 PLAYOFFS_URL = "https://www.hockey-reference.com/playoffs/NHL_2026.html"
 ```
 
-Also update `TEAM_NAME_MAP` if any franchises have relocated or been added.
+Also update `TEAM_NAME_MAP` if any franchises have relocated or been added. The map must include both city/region names and nickname variants for every team in the playoffs — missing entries cause elimination records to be silently skipped with a warning in the log.

--- a/scraper/docker-entrypoint.sh
+++ b/scraper/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Export Docker environment variables into a file that cron can source.
 # This is necessary because cron does not inherit the container's environment.
-printenv | grep -v '^_=' | sed "s/'/'\\\\''/g; s/=\(.*\)/='\1'/" > /app/env.sh
+printenv | grep -v '^_=' | sed "s/'/'\\\\''/g; s/^\([^=]*\)=\(.*\)/export \1='\2'/" > /app/env.sh
 
 python /app/startup_check.py || exit 1
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -39,39 +39,52 @@ PLAYOFFS_URL = f"https://www.hockey-reference.com/playoffs/NHL_{_YEAR}.html"
 # Must cover both full city/region names (used in team1) and
 # nickname variants (used in team2 after " over / lead ").
 TEAM_NAME_MAP = {
-    "Edmonton":      "EDM",
-    "Los Angeles":   "LAK",
-    "Vegas":         "VGK",
-    "Minnesota":     "MIN",
-    "Dallas":        "DAL",
-    "Colorado":      "COL",
-    "Winnipeg":      "WPG",
-    "St. Louis":     "STL",
+    "Anaheim":       "ANA",
+    "Boston":        "BOS",
+    "Buffalo":       "BUF",
     "Carolina":      "CAR",
-    "New Jersey":    "NJD",
-    "Washington":    "WSH",
-    "Montreal":      "MTL",
+    "Colorado":      "COL",
+    "Dallas":        "DAL",
+    "Edmonton":      "EDM",
     "Florida":       "FLA",
+    "Los Angeles":   "LAK",
+    "Minnesota":     "MIN",
+    "Montreal":      "MTL",
+    "New Jersey":    "NJD",
+    "Ottawa":        "OTT",
+    "Philadelphia":  "PHI",
+    "Pittsburgh":    "PIT",
+    "St. Louis":     "STL",
     "Tampa Bay":     "TBL",
     "Toronto":       "TOR",
-    "Ottawa":        "OTT",
+    "Utah":          "UTA",
+    "Vegas":         "VGK",
+    "Washington":    "WSH",
+    "Winnipeg":      "WPG",
     # Nickname variants
-    "Kings":         "LAK",
-    "Oilers":        "EDM",
-    "Golden Knights":"VGK",
-    "Wild":          "MIN",
-    "Stars":         "DAL",
     "Avalanche":     "COL",
-    "Jets":          "WPG",
+    "Bluejackets":   "CBJ",
     "Blues":         "STL",
-    "Hurricanes":    "CAR",
-    "Devils":        "NJD",
-    "Capitals":      "WSH",
+    "Bruins":        "BOS",
     "Canadiens":     "MTL",
-    "Panthers":      "FLA",
+    "Capitals":      "WSH",
+    "Devils":        "NJD",
+    "Ducks":         "ANA",
+    "Flyers":        "PHI",
+    "Golden Knights":"VGK",
+    "Hockey Club":   "UTA",
+    "Hurricanes":    "CAR",
+    "Jets":          "WPG",
+    "Kings":         "LAK",
     "Lightning":     "TBL",
     "Maple Leafs":   "TOR",
+    "Oilers":        "EDM",
+    "Panthers":      "FLA",
+    "Penguins":      "PIT",
+    "Sabres":        "BUF",
     "Senators":      "OTT",
+    "Stars":         "DAL",
+    "Wild":          "MIN",
 }
 
 
@@ -91,7 +104,7 @@ def get_db():
 def fetch_soup(url: str) -> BeautifulSoup:
     resp = requests.get(url, headers=HEADERS, timeout=30)
     resp.raise_for_status()
-    return BeautifulSoup(resp.text, "lxml")
+    return BeautifulSoup(resp.content, "lxml")
 
 
 def parse_stats_table(soup: BeautifulSoup) -> list[dict]:
@@ -99,7 +112,10 @@ def parse_stats_table(soup: BeautifulSoup) -> list[dict]:
     Parse a hockey-reference #stats table into a list of dicts.
 
     Hockey-reference quirks handled:
-    - Repeated sub-header rows (tr.thead class) are skipped.
+    - The outer <thead> only has group-level headers (Scoring, Goals, etc.).
+      The actual column names (Player, Tm, G, A, ...) live in the first
+      <tr class="thead"> inside <tbody> — that row is used for the header.
+    - Repeated sub-header rows (tr.thead class) in tbody are skipped for data.
     - Rows where the first cell equals 'Rk' are sub-headers and are skipped.
     - Duplicate column names are suffixed with _1, _2, ... to avoid key collisions
       (e.g. the skaters table has two 'EV', 'PP', 'SH' columns).
@@ -108,8 +124,16 @@ def parse_stats_table(soup: BeautifulSoup) -> list[dict]:
     if table is None:
         raise ValueError("Could not find table#stats on page")
 
-    thead = table.find("thead")
-    raw_headers = [th.get_text(strip=True) for th in thead.find_all("th")]
+    tbody = table.find("tbody")
+    # Skaters: column names are in a <tr class="thead"> inside tbody.
+    # Goalies: column names are in the last <tr> of the outer <thead>.
+    header_row = tbody.find("tr", class_="thead")
+    if header_row is None:
+        thead_rows = table.find("thead").find_all("tr")
+        header_row = thead_rows[-1]
+    if header_row is None:
+        raise ValueError("Could not find column header row in table#stats")
+    raw_headers = [th.get_text(strip=True) for th in header_row.find_all(["th", "td"])]
 
     # Deduplicate column names
     seen: dict[str, int] = {}
@@ -123,7 +147,7 @@ def parse_stats_table(soup: BeautifulSoup) -> list[dict]:
             headers.append(h)
 
     rows = []
-    for tr in table.find("tbody").find_all("tr"):
+    for tr in tbody.find_all("tr"):
         if "thead" in tr.get("class", []):
             continue
         cells = [td.get_text(strip=True) for td in tr.find_all(["td", "th"])]
@@ -225,7 +249,7 @@ def scrape_eliminations(today: date) -> list[tuple]:
             continue
 
         # Parse "{team1_full} over|lead {team2_full} XXX"
-        parts = re.split(r"\s+(?:over|lead)\s+", series_str, maxsplit=1)
+        parts = re.split(r"\s*(?:over|lead)\s*", series_str, maxsplit=1)
         if len(parts) != 2:
             log.warning("Could not split series string: %r", series_str)
             continue

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -67,11 +67,6 @@ server <- function(input, output, session) {
       "SELECT scrape_date, name_ref, team, wins, shutouts, goals, assists FROM goalies"
     )
 
-    eliminations <- dbGetQuery(
-      conn,
-      "SELECT team, eliminated_date FROM eliminations"
-    )
-
     # Guard: nothing to plot yet
     if (nrow(picks) == 0 || (nrow(skaters_db) == 0 && nrow(goalies_db) == 0)) {
       return(
@@ -81,7 +76,7 @@ server <- function(input, output, session) {
       )
     }
 
-    results <- compute_scores(picks, skaters_db, goalies_db, eliminations)
+    results <- compute_scores(picks, skaters_db, goalies_db)
 
     # --- Plot --------------------------------------------------------------
 

--- a/shiny/scoring.R
+++ b/shiny/scoring.R
@@ -3,22 +3,22 @@
 
 #' Compute per-participant cumulative scores across all scrape dates.
 #'
-#' @param picks        data.frame: participant, position_slot, name_ref, position_type
-#' @param skaters_db   data.frame: scrape_date, name_ref, team, goals, assists
-#' @param goalies_db   data.frame: scrape_date, name_ref, team, wins, shutouts, goals, assists
-#' @param eliminations data.frame: team, eliminated_date
+#' @param picks      data.frame: participant, position_slot, name_ref, position_type
+#' @param skaters_db data.frame: scrape_date, name_ref, team, goals, assists
+#' @param goalies_db data.frame: scrape_date, name_ref, team, wins, shutouts, goals, assists
+#' @param ...        ignored (accepts extra args for backwards compatibility)
 #'
 #' @return data.frame: participant, date, score
-compute_scores <- function(picks, skaters_db, goalies_db, eliminations) {
+compute_scores <- function(picks, skaters_db, goalies_db, ...) {
   # Skaters: goals + assists
   skaters_scored <- skaters_db |>
     dplyr::mutate(score = goals + assists) |>
-    dplyr::select(scrape_date, name_ref, team, score)
+    dplyr::select(scrape_date, name_ref, score)
 
   # Goalies: goals + assists + wins*2 + shutouts*3
   goalies_scored <- goalies_db |>
     dplyr::mutate(score = goals + assists + wins * 2L + shutouts * 3L) |>
-    dplyr::select(scrape_date, name_ref, team, score)
+    dplyr::select(scrape_date, name_ref, score)
 
   stats <- dplyr::bind_rows(skaters_scored, goalies_scored)
   all_dates <- sort(unique(stats$scrape_date))
@@ -27,18 +27,8 @@ compute_scores <- function(picks, skaters_db, goalies_db, eliminations) {
     day_stats <- stats[stats$scrape_date == d, ]
 
     picks |>
-      dplyr::left_join(
-        day_stats[, c("name_ref", "team", "score")],
-        by = "name_ref"
-      ) |>
-      dplyr::left_join(eliminations, by = "team") |>
-      dplyr::mutate(
-        effective_score = dplyr::case_when(
-          is.na(score)                                    ~ 0L,
-          !is.na(eliminated_date) & eliminated_date <= d ~ 0L,
-          TRUE                                            ~ score
-        )
-      ) |>
+      dplyr::left_join(day_stats[, c("name_ref", "score")], by = "name_ref") |>
+      dplyr::mutate(effective_score = dplyr::if_else(is.na(score), 0L, score)) |>
       dplyr::group_by(participant) |>
       dplyr::summarise(score = sum(effective_score), .groups = "drop") |>
       dplyr::mutate(date = d)

--- a/shiny/tests/testthat/test_scoring.R
+++ b/shiny/tests/testthat/test_scoring.R
@@ -118,40 +118,28 @@ test_that("goalie score is goals + assists + wins*2 + shutouts*3", {
 # Elimination logic
 # ---------------------------------------------------------------------------
 
-test_that("player on eliminated team scores 0 from elimination date onward", {
-  eliminations <- data.frame(
-    team            = "EDM",
-    eliminated_date = as.Date("2025-05-02"),
-    stringsAsFactors = FALSE
-  )
+test_that("player on eliminated team retains accumulated score after elimination", {
   results <- compute_scores(
-    picks        = make_picks() |> filter(participant == "Alice", position_slot == "center_1"),
-    skaters_db   = make_skaters() |> filter(name_ref == "Connor McDavid"),
-    goalies_db   = make_goalies()[0, ],
-    eliminations = eliminations
+    picks      = make_picks() |> filter(participant == "Alice", position_slot == "center_1"),
+    skaters_db = make_skaters() |> filter(name_ref == "Connor McDavid"),
+    goalies_db = make_goalies()[0, ]
   )
-  # May 1: EDM not yet eliminated → full score (3+5=8)
+  # May 1: goals=3, assists=5 → 8
   day1 <- results |> filter(date == as.Date("2025-05-01"))
   expect_equal(day1$score, 8L)
 
-  # May 2: EDM eliminated on May 2 → score is 0
+  # May 2: cumulative stats freeze at goals=4, assists=7 → 11 (score never drops)
   day2 <- results |> filter(date == as.Date("2025-05-02"))
-  expect_equal(day2$score, 0L)
+  expect_equal(day2$score, 4L + 7L)
 })
 
-test_that("player on active team is unaffected by another team's elimination", {
-  eliminations <- data.frame(
-    team            = "WPG",
-    eliminated_date = as.Date("2025-05-01"),
-    stringsAsFactors = FALSE
-  )
+test_that("scoring is unaffected by other teams' results", {
   results <- compute_scores(
-    picks        = make_picks() |> filter(participant == "Alice", position_slot == "center_1"),
-    skaters_db   = make_skaters() |> filter(name_ref == "Connor McDavid"),
-    goalies_db   = make_goalies()[0, ],
-    eliminations = eliminations
+    picks      = make_picks() |> filter(participant == "Alice", position_slot == "center_1"),
+    skaters_db = make_skaters() |> filter(name_ref == "Connor McDavid"),
+    goalies_db = make_goalies()[0, ]
   )
-  # EDM is not eliminated; Alice's skater should still score normally
+  # Alice's EDM skater scores on cumulative stats regardless of other teams
   day2 <- results |> filter(date == as.Date("2025-05-02"))
   expect_equal(day2$score, 4L + 7L)  # goals=4, assists=7
 })


### PR DESCRIPTION
  ---
  Summary

  This branch represents the full rebuild of the NHL Playoff Pool from the original R-only flat-file implementation to a
   production PostgreSQL + Python scraper + containerized R Shiny stack, deployed for the 2026 season.

  ---
  Architecture

  Replaced the legacy R scripts and dated CSV files with a proper data pipeline:

  - PostgreSQL (WSL, local) as the database backend with a formal schema (picks, players, skaters, goalies,
  eliminations)
  - Python scraper (scraper/scraper.py) running on a cron schedule inside Docker (21:00 EST daily), pulling cumulative
  stats from hockey-reference and upserting to the DB
  - Two R Shiny containers (shiny_pool1, shiny_pool2), same image, differentiated by POOL_ID env var, serving live
  standings graphs
  - nginx reverse proxy with HTTPS (Let's Encrypt via DuckDNS DNS-01 challenge) and HTTP Basic Auth
  - All services defined in docker-compose.yml; legacy R scripts moved to legacy/

  ---
  2026 Season Picks Format

  The Google Form pick structure changed from the 2025 format. Updated db/ingest_picks.py to handle the new column
  naming:

  ┌──────────┬────────────────────────┬─────────────┐
  │          │     2025 (legacy)      │    2026     │
  ├──────────┼────────────────────────┼─────────────┤
  │ Forwards │ 8 centers + 10 wingers │ 12 forwards │
  ├──────────┼────────────────────────┼─────────────┤
  │ Defence  │ 6                      │ 8           │
  ├──────────┼────────────────────────┼─────────────┤
  │ Goalies  │ 3                      │ 4           │
  ├──────────┼────────────────────────┼─────────────┤
  │ Total    │ 27                     │ 24          │
  └──────────┴────────────────────────┴─────────────┘

  Column regex updated from center\|winger\|defenseman\|goalie → forward\|defenseman\|goalie.

  ---
  Scraper Fixes (discovered during 2026 launch)

  Three bugs found and fixed when running against live 2026 data:

  1. Header row parsing — hockey-reference moved the actual column names (Player, Tm, G, A…) into a <tr class="thead">
  inside <tbody> for the skaters page (outer <thead> only has group labels). parse_stats_table() updated to detect both
  locations.
  2. UTF-8 encoding (mojibake) — requests was guessing Latin-1 for the response encoding, corrupting diacritic names
  (e.g. Tim Stützle → Tim StÃ¼tzle). Fixed by passing resp.content (bytes) to BeautifulSoup instead of resp.text.
  3. TEAM_NAME_MAP incomplete — six 2026 playoff teams were missing (BUF, PHI, ANA, UTA, PIT, BOS), causing their
  eliminations to be silently skipped. Map updated with full city and nickname variants for all current franchises.

  ---
  Player Key (db/hockey_player_key.csv)

  Rebuilt from scratch for 2026. The 2025 key used LASTNAME TEAM format; the 2026 Google Form uses First Last (TEAM).
  New key generated by:
  1. Running a manual scrape to populate the DB with live 2026 player names
  2. Stripping the team suffix from form names and matching against scraped name_ref values
  3. Manually resolving 4 name variant mismatches (Svechnikov, Marner, Peterka, York) and 3 diacritic mismatches found
  post-launch (Pastrňák, Nečas, Dostál)

  ---
  Scoring Algorithm Change

  Old behaviour: The compute_scores() function joined against the eliminations table and zeroed out any player's
  contribution on dates after their team's elimination. Because stats are stored as cumulative totals, this caused
  scores to drop to zero — contradicting the stated rule that points are never deducted.

  New behaviour: Eliminations are ignored entirely in scoring. Eliminated players' cumulative stats freeze naturally on
  hockey-reference at their final total; subsequent scrapes continue to show that frozen value. Scores plateau rather
  than drop. The eliminations table is still populated by the scraper for reference but is no longer queried by the
  Shiny app.

  Test suite updated to reflect the new expected behaviour (15/15 passing).

  ---
  Documentation

  Full docs suite added under docs/:
  - architecture.md — system design and data flow
  - database.md — schema reference and diagnostic queries
  - docker-guide.md — container usage and troubleshooting
  - scraper.md — parsing quirks, encoding notes, elimination logic
  - network-setup.md — WSL2 mirrored networking, DuckDNS, certbot, nginx, .htpasswd management
  - README.md — complete rewrite with quick-reference table, scoring rules, setup workflow
